### PR TITLE
chore: atualizar jwt-decode de 3.1.2 para 4.0.0 e ajustar imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"antd": "^5.8.5",
 		"axios": "^1.5.0",
 		"install": "^0.13.0",
-		"jwt-decode": "^3.1.2",
+		"jwt-decode": "^4.0.0",
 		"npm": "^10.1.0",
 		"phosphor-react": "^1.4.1",
 		"react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       jwt-decode:
-        specifier: ^3.1.2
-        version: 3.1.2
+        specifier: ^4.0.0
+        version: 4.0.0
       npm:
         specifier: ^10.1.0
         version: 10.8.3
@@ -961,8 +961,9 @@ packages:
   json2mq@0.2.0:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
 
-  jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2356,7 +2357,7 @@ snapshots:
     dependencies:
       string-convert: 0.2.1
 
-  jwt-decode@3.1.2: {}
+  jwt-decode@4.0.0: {}
 
   loose-envify@1.4.0:
     dependencies:

--- a/src/stores/User/useUserStore.tsx
+++ b/src/stores/User/useUserStore.tsx
@@ -5,7 +5,7 @@ import api, {
 } from "@/services/api"
 import { makeApiHeaders } from "@/services/utils"
 import type { User } from "@/types/usuario"
-import jwt_decode from "jwt-decode"
+import { jwtDecode } from "jwt-decode"
 import { create } from "zustand"
 
 type LoginBody = {
@@ -33,7 +33,7 @@ export type DecodedToken = {
 
 const getUserData = async (token: string): Promise<User | undefined> => {
 	try {
-		const decodedToken: DecodedToken = jwt_decode(token)
+		const decodedToken: DecodedToken = jwtDecode(token)
 		const headers = makeApiHeaders(token)
 		const res = await api.get<User>(`/users/${decodedToken.sing.id}`, {
 			headers,


### PR DESCRIPTION
Atualizada a biblioteca jwt-decode para a versão 4.0.0. Adaptados import e uso da função jwtDecode no useUserStore.tsx para compatibilidade.

- Atualização da dependência jwt-decode de 3.1.2 para 4.0.0 no package.json
- Ajuste do import de jwt_decode para jwtDecode no useUserStore.tsx
- Adaptação do método jwt_decode(token) para jwtDecode(token) no useUserStore.tsx
- Atualização do pnpm-lock.yaml para refletir a nova versão da dependência
- Garantia de compatibilidade da nova versão do jwt-decode com o projeto