### PR TITLE
chore: atualizar configuração do Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+    target-branch: "development"
 
-  - package-ecosystem: npm
+  - package-ecosystem: pnpm
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
Adiciona `target-branch` como "development" e altera o ecossistema de pacotes de `npm` para `pnpm` no arquivo de configuração do Dependabot.

- Adicionado campo `target-branch: "development"` para definir o branch alvo das atualizações.
- Modificado `package-ecosystem` de `npm` para `pnpm` para refletir a alteração na gestão de pacotes.
- Mantido intervalo de atualização como `daily` para garantir atualizações frequentes.