### PR TITLE
Inclusão de endereço para fornecedores

### DIFF
--- a/src/components/InfoLine/index.tsx
+++ b/src/components/InfoLine/index.tsx
@@ -12,7 +12,7 @@ const { Paragraph } = Typography
 export const InfoLine = ({
 	children,
 	title,
-	copyable = false,
+	copyable,
 	...rest
 }: InfoLineProps) => {
 	return (
@@ -27,6 +27,7 @@ export const InfoLine = ({
 				{...(copyable && {
 					copyable: {
 						tooltips: false,
+						text: typeof copyable !== "boolean" ? copyable.text : undefined,
 					},
 				})}
 				{...rest}

--- a/src/components/InfoLine/styles.ts
+++ b/src/components/InfoLine/styles.ts
@@ -4,6 +4,7 @@ import styled from "styled-components"
 export const InfoLineWrapper = styled.div`
     display: flex;
     margin-bottom: ${spacing.xxxs};
+    flex: 1;
 
     .lineTitle, .lineContent {
         margin: 0;
@@ -11,7 +12,7 @@ export const InfoLineWrapper = styled.div`
     }
 
     .lineTitle {
-        flex: 0.20;
+        flex: 0.25;
     }
 
     .lineContent {

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -15,10 +15,11 @@ import {
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	required?: boolean
 	label?: string
-	inputType?: string
+	inputType?: "text" | "password" | "email" | "number" | "textarea"
 	errorMessage?: string
 	error?: boolean
 	className?: string
+	loading?: boolean
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -31,6 +32,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 			error = false,
 			className,
 			required = false,
+			loading = false,
 			...rest
 		}: InputProps,
 		ref,
@@ -73,6 +75,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 						type={inputType}
 						error={hasError}
 						placeholder={placeholder}
+						// loading={loading}
 						{...rest}
 						ref={ref}
 					/>

--- a/src/components/Menu/useGetMenuItems.tsx
+++ b/src/components/Menu/useGetMenuItems.tsx
@@ -35,8 +35,6 @@ export const useGetMenuItems = () => {
 		id: decodedToken?.sing?.id,
 		token: token,
 	})
-	console.log(decodedToken)
-	console.log({ query })
 
 	const user = useUserStore((state) => state.user)
 	const userRoutes = user?.profile?.routes
@@ -45,7 +43,6 @@ export const useGetMenuItems = () => {
 	// const userPaths = userRoutes.map((route) => route.path)
 
 	routes.push(...defaultMenuItems)
-	console.log("aqui", defaultMenuItems)
 
 	return routes
 }

--- a/src/helpers/general.tsx
+++ b/src/helpers/general.tsx
@@ -20,6 +20,13 @@ export function cnpjMask(cnpj: string) {
 	return v
 }
 
+export function cepMask(cep: string) {
+	return cep
+		.replace(/\D/g, "")
+		.replace(/(\d{5})(\d)/, "$1-$2")
+		.replace(/(-\d{3})\d+?$/, "$1")
+}
+
 export function onlyNumbersCnpj(cnpj: string) {
 	return cnpj.replace(/\D/g, "")
 }
@@ -66,4 +73,9 @@ export function isValidToken(token: string) {
 	const decodedToken: DecodedToken = jwtDecode(token)
 	const currentDate = new Date()
 	return new Date(decodedToken.exp * 1000) > currentDate
+}
+
+export const getTextValue = (value: string | undefined) => {
+	if (!value?.length) return <i>Não informado</i>
+	return value
 }

--- a/src/helpers/general.tsx
+++ b/src/helpers/general.tsx
@@ -27,6 +27,10 @@ export function cepMask(cep: string) {
 		.replace(/(-\d{3})\d+?$/, "$1")
 }
 
+export function onlyNumbersCep(cep: string) {
+	return cep.replace(/\D/g, "")
+}
+
 export function onlyNumbersCnpj(cnpj: string) {
 	return cnpj.replace(/\D/g, "")
 }
@@ -78,4 +82,9 @@ export function isValidToken(token: string) {
 export const getTextValue = (value: string | undefined) => {
 	if (!value?.length) return <i>Não informado</i>
 	return value
+}
+
+export const isValidCEP = (cep: string) => {
+	if (!cep?.length) return false
+	return cep.length === 8
 }

--- a/src/pages/Suppliers/AddressForm/index.tsx
+++ b/src/pages/Suppliers/AddressForm/index.tsx
@@ -1,0 +1,184 @@
+import { LabelStyled } from "@/components/Input/styles"
+import { cepMask, isValidCEP, onlyNumbersCep } from "@/helpers/general"
+import { addressSchema, type AddressSchemaType, EMPTY_ADDRESS, } from "@/pages/Suppliers/AddressForm/schema"
+import { useGetAddressByCEP } from "@/services/adressServices"
+import { useGetSuppliers } from "@/services/useGetSuppliers"
+import { FormStyled } from "@/style/global"
+import { yupResolver } from "@hookform/resolvers/yup"
+import { Input as AntInput, Modal } from "antd"
+import { useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { useSearchParams } from "react-router-dom"
+import * as S from "./styles"
+
+export const AddressForm = () => {
+	const [searchParams, setSearchParams] = useSearchParams()
+	const [cep, setCep] = useState("")
+
+	const { data: suppliers } = useGetSuppliers()
+	const { data: addressByCep, isLoading } = useGetAddressByCEP(cep)
+
+	const action = searchParams.get("action")
+	const isCreatingNew = action === "create_address"
+	const isEditing = action === "edit_address"
+	const addressId = searchParams.get("address_id")
+	const supplierId = searchParams.get("supplier_id")
+
+	const supplier = suppliers?.suppliers.find(
+		(supplier) => supplier.id === supplierId,
+	)
+	const address = supplier?.addresses?.find(
+		(address) => address.id === addressId,
+	)
+
+	const isModalOpen =
+		isCreatingNew || (isEditing && !!addressId && !!address?.id)
+
+	const initialValues = useMemo(() => {
+		if (!isEditing || !address) {
+			return EMPTY_ADDRESS
+		}
+
+		if (address.zipcode) {
+			setCep(address.zipcode)
+		}
+
+		return {
+			lograd: address?.lograd ?? "",
+			number: address?.number ?? "",
+			zipcode: address?.zipcode ?? "",
+			city: address?.city ?? "",
+			state: address?.state ?? "",
+			district: address?.district ?? "",
+			complement: address?.complement ?? "",
+			addressType: address?.addressType?.description ?? "",
+		}
+	}, [address, isEditing])
+
+	// console.log("initial", initialValues)
+	// console.log("cep", cep)
+
+	const handleCancel = () => {
+		setSearchParams((params) => {
+			params.delete("action")
+			params.delete("address_id")
+			return params
+		})
+	}
+
+	const { register, setValue, watch, trigger } = useForm<AddressSchemaType>({
+		resolver: yupResolver(addressSchema),
+		values: initialValues,
+	})
+
+	useEffect(() => {
+		console.count("useEffect")
+		if (
+			!isLoading &&
+			addressByCep?.cep &&
+			onlyNumbersCep(addressByCep.cep) === cep
+		) {
+			console.count("setValue")
+			setValue("zipcode", addressByCep.cep)
+			setValue("city", addressByCep.localidade)
+			setValue("state", addressByCep.uf)
+			setValue("district", addressByCep.bairro)
+			setValue("lograd", addressByCep.logradouro)
+			setCep("")
+		}
+	}, [isLoading, addressByCep, cep, setValue])
+
+	// console.log("valores", watch())
+
+	return (
+		<Modal
+			open={isModalOpen}
+			title={isCreatingNew ? "Novo endereço" : "Editar endereço"}
+			onCancel={handleCancel}
+		>
+			<FormStyled>
+				<S.FormLine>
+					<LabelStyled htmlFor={"cep"}>CEP</LabelStyled>
+					<AntInput.Search
+						size={"large"}
+						name={"cep"}
+						loading={isLoading}
+						onChange={(e) => {
+							setCep(onlyNumbersCep(e.target.value))
+							if (isValidCEP(e.target.value)) {
+							}
+							setValue("zipcode", onlyNumbersCep(e.target.value))
+							trigger("zipcode")
+						}}
+						value={cepMask(watch("zipcode"))}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"lograd"}>Rua</LabelStyled>
+
+					<AntInput
+						size={"large"}
+						placeholder={"Rua"}
+						disabled={isLoading}
+						{...register("lograd")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"number"}>Número</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Número"}
+						disabled={isLoading}
+						{...register("number")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"complement"}>Complemento</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Complemento"}
+						disabled={isLoading}
+						{...register("complement")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"district"}>Bairro</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Bairro"}
+						disabled={isLoading}
+						{...register("district")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"city"}>Cidade</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Cidade"}
+						disabled={isLoading}
+						{...register("city")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"state"}>Estado</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Estado"}
+						disabled={isLoading}
+						{...register("state")}
+					/>
+				</S.FormLine>
+				<S.FormLine>
+					<LabelStyled htmlFor={"addressType"}>Tipo de endereço</LabelStyled>
+					<AntInput
+						size={"large"}
+						placeholder={"Tipo de endereço"}
+						disabled={isLoading}
+						{...register("addressType")}
+					/>
+				</S.FormLine>
+			</FormStyled>
+			teste
+		</Modal>
+	)
+}

--- a/src/pages/Suppliers/AddressForm/index.tsx
+++ b/src/pages/Suppliers/AddressForm/index.tsx
@@ -31,7 +31,7 @@ export const AddressForm = () => {
 	const [uf, setUf] = useState("")
 
 	const { data: suppliers, query: suppliersQuery } = useGetSuppliers()
-	const { addAddress } = useGetSuppliersActions()
+	const { addAddress, editAddress } = useGetSuppliersActions()
 	const { data: addressByCep, isLoading: isLoadingCEP } =
 		useGetAddressByCEP(cep)
 	const { data: ufs, isLoading: isLoadingUFs } = useGetUFs()
@@ -112,9 +112,6 @@ export const AddressForm = () => {
 		setUf("")
 	}
 
-	console.log("valores", watch())
-	console.log(addressByCep)
-
 	const handleSubmit = async () => {
 		const addressType = getValues("addressType")
 		const values = {
@@ -146,13 +143,43 @@ export const AddressForm = () => {
 		}
 	}
 
+	const handleEdit = async () => {
+		const addressType = getValues("addressType")
+		const values = {
+			...getValues(),
+			addressType: { description: addressType },
+		}
+
+		if (!supplierId || !addressId) return
+		setLoadingPost(true)
+
+		try {
+			await editAddress(supplierId, addressId, values)
+			await suppliersQuery.refetch()
+			showNotification({
+				type: "SUCCESS",
+				message: "Endereço atualizado com sucesso",
+				description: "",
+			})
+			handleCancel()
+		} catch (err) {
+			const parsedError = parseError(err as ErrorExtended)
+			showNotification({
+				type: "ERROR",
+				message: parsedError ?? "Erro ao atualizar endereço",
+				description: "Verifique seus dados e tente novamente",
+			})
+		} finally {
+			setLoadingPost(false)
+		}
+	}
 	return (
 		<Modal
 			open={isModalOpen}
 			title={isCreatingNew ? "Novo endereço" : "Editar endereço"}
 			onCancel={handleCancel}
 			okText={isCreatingNew ? "Adicionar endereço" : "Salvar"}
-			onOk={handleSubmit}
+			onOk={isEditing ? handleEdit : handleSubmit}
 			okButtonProps={{ loading: loadingPost, disabled: !isValid }}
 		>
 			<FormStyled>

--- a/src/pages/Suppliers/AddressForm/schema.ts
+++ b/src/pages/Suppliers/AddressForm/schema.ts
@@ -1,0 +1,25 @@
+import * as yup from "yup"
+
+export const addressSchema = yup.object().shape({
+	lograd: yup.string().required("Campo obrigatório"),
+	number: yup.string().required("Campo obrigatório"),
+	zipcode: yup.string().required("Campo obrigatório"),
+	city: yup.string().required("Campo obrigatório"),
+	state: yup.string().required("Campo obrigatório"),
+	district: yup.string().required("Campo obrigatório"),
+	complement: yup.string(),
+	addressType: yup.string().required("Campo obrigatório"),
+})
+
+export type AddressSchemaType = yup.InferType<typeof addressSchema>
+
+export const EMPTY_ADDRESS: AddressSchemaType = {
+	lograd: "",
+	number: "",
+	zipcode: "",
+	city: "",
+	state: "",
+	district: "",
+	complement: "",
+	addressType: "",
+}

--- a/src/pages/Suppliers/AddressForm/styles.ts
+++ b/src/pages/Suppliers/AddressForm/styles.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components"
+
+export const FormLine = styled.div`
+    display: flex;
+    flex-direction: column;
+`

--- a/src/pages/Suppliers/List/NewSupplier/index.tsx
+++ b/src/pages/Suppliers/List/NewSupplier/index.tsx
@@ -25,7 +25,7 @@ const EMPTY_INITIAL_VALUES: NewSupplierSchema = {
 	email: "",
 	fone: "",
 	legalName: "",
-	ERPcode: "",
+	ERPCode: "",
 	code: "",
 	users: [],
 }
@@ -59,7 +59,7 @@ export const NewSupplier = () => {
 			email: supplier.email,
 			fone: supplier.fone,
 			legalName: supplier.legalName,
-			ERPcode: supplier.ERPCode,
+			ERPCode: supplier.ERPCode,
 			code: supplier.code,
 			users: supplier?.users?.map((user) => user.id),
 		}
@@ -86,6 +86,9 @@ export const NewSupplier = () => {
 
 		setIsLoading(true)
 		const values = methods.getValues()
+		if (values?.cnpj?.length) {
+			values.cnpj = onlyNumbersCnpj(values.cnpj)
+		}
 
 		try {
 			await updateSupplier(id, values)
@@ -110,9 +113,9 @@ export const NewSupplier = () => {
 
 	const handleSubmit = async (data: NewSupplierSchema) => {
 		setIsLoading(true)
-		const updatedData = {
-			...data,
-			cnpj: onlyNumbersCnpj(data.cnpj),
+		const updatedData = { ...data }
+		if (updatedData?.cnpj?.length) {
+			updatedData.cnpj = onlyNumbersCnpj(updatedData.cnpj)
 		}
 
 		try {
@@ -182,8 +185,8 @@ export const NewSupplier = () => {
 					required
 					label="Código de ERP"
 					placeholder="ERP do fornecedor"
-					errorMessage={methods.formState.errors.ERPcode?.message}
-					{...methods.register("ERPcode")}
+					errorMessage={methods.formState.errors.ERPCode?.message}
+					{...methods.register("ERPCode")}
 				/>
 				<Input
 					required

--- a/src/pages/Suppliers/List/NewSupplier/index.tsx
+++ b/src/pages/Suppliers/List/NewSupplier/index.tsx
@@ -25,7 +25,7 @@ const EMPTY_INITIAL_VALUES: NewSupplierSchema = {
 	email: "",
 	fone: "",
 	legalName: "",
-	ERPCode: "",
+	ERPcode: "",
 	code: "",
 	users: [],
 }
@@ -59,7 +59,7 @@ export const NewSupplier = () => {
 			email: supplier.email,
 			fone: supplier.fone,
 			legalName: supplier.legalName,
-			ERPCode: supplier.ERPCode,
+			ERPcode: supplier.ERPcode,
 			code: supplier.code,
 			users: supplier?.users?.map((user) => user.id),
 		}
@@ -185,8 +185,8 @@ export const NewSupplier = () => {
 					required
 					label="Código de ERP"
 					placeholder="ERP do fornecedor"
-					errorMessage={methods.formState.errors.ERPCode?.message}
-					{...methods.register("ERPCode")}
+					errorMessage={methods.formState.errors.ERPcode?.message}
+					{...methods.register("ERPcode")}
 				/>
 				<Input
 					required

--- a/src/pages/Suppliers/List/NewSupplier/schema.ts
+++ b/src/pages/Suppliers/List/NewSupplier/schema.ts
@@ -4,7 +4,7 @@ export const newSupplierSchema = yup.object({
 	name: yup.string().required("Campo obrigatório"),
 	cnpj: yup.string(),
 	legalName: yup.string(),
-	ERPCode: yup.string(),
+	ERPcode: yup.string(),
 	code: yup.string(),
 	fone: yup.string(),
 	email: yup.string(),

--- a/src/pages/Suppliers/List/NewSupplier/schema.ts
+++ b/src/pages/Suppliers/List/NewSupplier/schema.ts
@@ -2,12 +2,12 @@ import * as yup from "yup"
 
 export const newSupplierSchema = yup.object({
 	name: yup.string().required("Campo obrigatório"),
-	cnpj: yup.string().required("Campo obrigatório"),
-	legalName: yup.string().required("Campo obrigatório"),
-	ERPcode: yup.string().required("Campo obrigatório"),
-	code: yup.string().required("Campo obrigatório"),
+	cnpj: yup.string(),
+	legalName: yup.string(),
+	ERPCode: yup.string(),
+	code: yup.string(),
 	fone: yup.string(),
-	email: yup.string().email("Email inválido"),
+	email: yup.string(),
 	users: yup.array(yup.string().required("Campo obrigatório")),
 })
 

--- a/src/pages/Suppliers/List/SupplierDetails/index.tsx
+++ b/src/pages/Suppliers/List/SupplierDetails/index.tsx
@@ -1,9 +1,16 @@
 import Button from "@/components/Button"
 import { InfoLine } from "@/components/InfoLine"
-import { cnpjMask, onlyNumbersCnpj } from "@/helpers/general"
+import {
+	cepMask,
+	cnpjMask,
+	getTextValue,
+	onlyNumbersCnpj,
+} from "@/helpers/general"
 import { useGetSuppliers } from "@/services/useGetSuppliers"
-import { Divider, Drawer, Space, Typography } from "antd"
+import { FormFooter } from "@/style/global"
+import { Card, Divider, Drawer, Popconfirm, Space, Tag, Typography } from "antd"
 import { useSearchParams } from "react-router-dom"
+import * as S from "./styles"
 
 export const SupplierDetails = () => {
 	const [searchParams, setSearchParams] = useSearchParams()
@@ -13,6 +20,14 @@ export const SupplierDetails = () => {
 		(supplier) => supplier.id === supplierId,
 	)
 	const isDrawerOpen = !!supplierId && !!supplier?.id
+
+	const handleDeleteAddress = async (id: string) => {
+		console.log(id)
+	}
+
+	const handleEditAddress = async (id: string) => {
+		console.log(id)
+	}
 
 	return (
 		<Drawer
@@ -44,43 +59,91 @@ export const SupplierDetails = () => {
 		>
 			<div>
 				<Typography.Title level={4}>Detalhes do fornecedor</Typography.Title>
-				<InfoLine title={"Nome"}>{supplier?.name}</InfoLine>
+				<InfoLine title={"Nome"}>{getTextValue(supplier?.name)}</InfoLine>
 				<InfoLine
 					title={"CNPJ"}
 					copyable={{
 						text: supplier?.cnpj ? onlyNumbersCnpj(supplier.cnpj) : "",
 					}}
 				>
-					{supplier?.cnpj ? cnpjMask(supplier.cnpj) : "-"}
+					{supplier?.cnpj ? cnpjMask(supplier.cnpj) : <i>Não informado</i>}
 				</InfoLine>
-				<InfoLine title={"Razão Social"}>{supplier?.legalName}</InfoLine>
-				<InfoLine title={"Código do ERP"}>{supplier?.ERPCode}</InfoLine>
-				<InfoLine title={"Código"}>{supplier?.code}</InfoLine>
-				<InfoLine title={"Telefone"}>{supplier?.fone}</InfoLine>
-				<InfoLine title={"Email"} copyable>
-					{supplier?.email}
+				<InfoLine title={"Razão Social"}>
+					{getTextValue(supplier?.legalName)}
+				</InfoLine>
+				<InfoLine title={"Código do ERP"}>
+					{getTextValue(supplier?.ERPcode)}
+				</InfoLine>
+				<InfoLine title={"Código"}>{getTextValue(supplier?.code)}</InfoLine>
+				<InfoLine title={"Telefone"}>{getTextValue(supplier?.fone)}</InfoLine>
+				<InfoLine title={"Email"} copyable={!!supplier?.email}>
+					{getTextValue(supplier?.email)}
 				</InfoLine>
 				<InfoLine title={"Usuários"}>
-					{supplier?.users?.map((user) => user.name).join(", ")}
+					{supplier?.users?.map((user) => (
+						<Tag key={user.id}>{user.name}</Tag>
+					))}
 				</InfoLine>
 			</div>
 			<Divider />
-			<div>
-				<Typography.Title level={4}>Endereços</Typography.Title>
+			<S.AddressWrapper>
+				<Typography.Title level={4}>
+					Endereços{" "}
+					<Typography.Text type="secondary">
+						({supplier?.addresses?.length})
+					</Typography.Text>
+				</Typography.Title>
 				{supplier?.addresses?.map((address) => (
-					<div key={address.id}>
-						<InfoLine title={"Logradouro"}>{address.lograd}</InfoLine>
-						<InfoLine title={"Número"}>{address.number}</InfoLine>
-						<InfoLine title={"Complemento"}>{address.complement}</InfoLine>
-						<InfoLine title={"Bairro"}>{address.district}</InfoLine>
-						<InfoLine title={"Cidade"}>{address.city}</InfoLine>
-						<InfoLine title={"Estado"}>{address.state}</InfoLine>
-						<InfoLine title={"CEP"} copyable>
-							{address.zipcode}
+					<Card
+						key={address.id}
+						actions={[
+							<Button
+								type={"link"}
+								key={"edit"}
+								onClick={() => handleEditAddress(address.id)}
+							>
+								Editar
+							</Button>,
+							<Popconfirm
+								key={"delete"}
+								title={`Tem certeza que deseja excluir o endereço ${address.lograd}?`}
+								onConfirm={() => handleDeleteAddress(address.id)}
+								okText={"Excluir"}
+								cancelText={"Cancelar"}
+								placement={"topLeft"}
+							>
+								<Button type={"link"} danger>
+									Excluir
+								</Button>
+							</Popconfirm>,
+						]}
+					>
+						<InfoLine title={"Logradouro"}>
+							{getTextValue(address.lograd)}
 						</InfoLine>
-					</div>
+						<InfoLine title={"Número"}>{getTextValue(address.number)}</InfoLine>
+						<InfoLine title={"Complemento"}>
+							{getTextValue(address.complement)}
+						</InfoLine>
+						<InfoLine title={"Bairro"}>
+							{getTextValue(address.district)}
+						</InfoLine>
+						<InfoLine title={"Cidade"}>{getTextValue(address.city)}</InfoLine>
+						<InfoLine title={"Estado"}>{getTextValue(address.state)}</InfoLine>
+						<InfoLine
+							title={"CEP"}
+							copyable={{
+								text: address.zipcode,
+							}}
+						>
+							{address.zipcode ? cepMask(address.zipcode) : "-"}
+						</InfoLine>
+					</Card>
 				))}
-			</div>
+				<FormFooter>
+					<Button type={"primary"}>Adicionar endereço</Button>
+				</FormFooter>
+			</S.AddressWrapper>
 		</Drawer>
 	)
 }

--- a/src/pages/Suppliers/List/SupplierDetails/index.tsx
+++ b/src/pages/Suppliers/List/SupplierDetails/index.tsx
@@ -1,11 +1,6 @@
 import Button from "@/components/Button"
 import { InfoLine } from "@/components/InfoLine"
-import {
-	cepMask,
-	cnpjMask,
-	getTextValue,
-	onlyNumbersCnpj,
-} from "@/helpers/general"
+import { cepMask, cnpjMask, getTextValue, onlyNumbersCnpj, } from "@/helpers/general"
 import { useGetSuppliers } from "@/services/useGetSuppliers"
 import { FormFooter } from "@/style/global"
 import { Card, Divider, Drawer, Popconfirm, Space, Tag, Typography } from "antd"
@@ -21,12 +16,23 @@ export const SupplierDetails = () => {
 	)
 	const isDrawerOpen = !!supplierId && !!supplier?.id
 
-	const handleDeleteAddress = async (id: string) => {
+	const handleDeleteAddress = (id: string) => {
 		console.log(id)
 	}
 
-	const handleEditAddress = async (id: string) => {
-		console.log(id)
+	const handleEditAddress = (id: string) => {
+		setSearchParams((params) => {
+			params.set("action", "edit_address")
+			params.set("address_id", id)
+			return params
+		})
+	}
+
+	const handleCreateAddress = () => {
+		setSearchParams((params) => {
+			params.set("action", "create_address")
+			return params
+		})
 	}
 
 	return (
@@ -58,7 +64,6 @@ export const SupplierDetails = () => {
 			}
 		>
 			<div>
-				<Typography.Title level={4}>Detalhes do fornecedor</Typography.Title>
 				<InfoLine title={"Nome"}>{getTextValue(supplier?.name)}</InfoLine>
 				<InfoLine
 					title={"CNPJ"}
@@ -141,7 +146,9 @@ export const SupplierDetails = () => {
 					</Card>
 				))}
 				<FormFooter>
-					<Button type={"primary"}>Adicionar endereço</Button>
+					<Button type={"primary"} onClick={handleCreateAddress}>
+						Adicionar endereço
+					</Button>
 				</FormFooter>
 			</S.AddressWrapper>
 		</Drawer>

--- a/src/pages/Suppliers/List/SupplierDetails/index.tsx
+++ b/src/pages/Suppliers/List/SupplierDetails/index.tsx
@@ -1,0 +1,86 @@
+import Button from "@/components/Button"
+import { InfoLine } from "@/components/InfoLine"
+import { cnpjMask, onlyNumbersCnpj } from "@/helpers/general"
+import { useGetSuppliers } from "@/services/useGetSuppliers"
+import { Divider, Drawer, Space, Typography } from "antd"
+import { useSearchParams } from "react-router-dom"
+
+export const SupplierDetails = () => {
+	const [searchParams, setSearchParams] = useSearchParams()
+	const { data: suppliers } = useGetSuppliers()
+	const supplierId = searchParams.get("supplier_id")
+	const supplier = suppliers?.suppliers.find(
+		(supplier) => supplier.id === supplierId,
+	)
+	const isDrawerOpen = !!supplierId && !!supplier?.id
+
+	return (
+		<Drawer
+			title="Detalhes do fornecedor"
+			open={isDrawerOpen}
+			width={600}
+			onClose={() => {
+				setSearchParams((params) => {
+					params.delete("supplier_id")
+					return params
+				})
+			}}
+			extra={
+				<Space>
+					<Button
+						onClick={() => {
+							setSearchParams((params) => {
+								if (!supplierId) return params
+								params.set("edit_supplier_id", supplierId)
+								params.delete("supplier_id")
+								return params
+							})
+						}}
+					>
+						Editar fornecedor
+					</Button>
+				</Space>
+			}
+		>
+			<div>
+				<Typography.Title level={4}>Detalhes do fornecedor</Typography.Title>
+				<InfoLine title={"Nome"}>{supplier?.name}</InfoLine>
+				<InfoLine
+					title={"CNPJ"}
+					copyable={{
+						text: supplier?.cnpj ? onlyNumbersCnpj(supplier.cnpj) : "",
+					}}
+				>
+					{supplier?.cnpj ? cnpjMask(supplier.cnpj) : "-"}
+				</InfoLine>
+				<InfoLine title={"Razão Social"}>{supplier?.legalName}</InfoLine>
+				<InfoLine title={"Código do ERP"}>{supplier?.ERPCode}</InfoLine>
+				<InfoLine title={"Código"}>{supplier?.code}</InfoLine>
+				<InfoLine title={"Telefone"}>{supplier?.fone}</InfoLine>
+				<InfoLine title={"Email"} copyable>
+					{supplier?.email}
+				</InfoLine>
+				<InfoLine title={"Usuários"}>
+					{supplier?.users?.map((user) => user.name).join(", ")}
+				</InfoLine>
+			</div>
+			<Divider />
+			<div>
+				<Typography.Title level={4}>Endereços</Typography.Title>
+				{supplier?.addresses?.map((address) => (
+					<div key={address.id}>
+						<InfoLine title={"Logradouro"}>{address.lograd}</InfoLine>
+						<InfoLine title={"Número"}>{address.number}</InfoLine>
+						<InfoLine title={"Complemento"}>{address.complement}</InfoLine>
+						<InfoLine title={"Bairro"}>{address.district}</InfoLine>
+						<InfoLine title={"Cidade"}>{address.city}</InfoLine>
+						<InfoLine title={"Estado"}>{address.state}</InfoLine>
+						<InfoLine title={"CEP"} copyable>
+							{address.zipcode}
+						</InfoLine>
+					</div>
+				))}
+			</div>
+		</Drawer>
+	)
+}

--- a/src/pages/Suppliers/List/SupplierDetails/styles.tsx
+++ b/src/pages/Suppliers/List/SupplierDetails/styles.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components"
+
+export const AddressWrapper = styled.div`
+    //border: 1px solid red;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 500px;
+    overflow: auto;
+`

--- a/src/pages/Suppliers/List/SupplierDetails/styles.tsx
+++ b/src/pages/Suppliers/List/SupplierDetails/styles.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components"
 
 export const AddressWrapper = styled.div`
-    //border: 1px solid red;
     display: flex;
     flex-direction: column;
     gap: 12px;

--- a/src/pages/Suppliers/List/Table/index.tsx
+++ b/src/pages/Suppliers/List/Table/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/services/useGetSuppliers"
 import { TableActionsWrapper, TableWrapper } from "@/style/global"
 import { Drawer, Popconfirm, Table, type TableColumnsType } from "antd"
-import { Pencil, Trash } from "phosphor-react"
+import { Eye, Pencil, Trash } from "phosphor-react"
 import React, { useMemo } from "react"
 import { useSearchParams } from "react-router-dom"
 import * as S from "./styles"
@@ -121,10 +121,20 @@ export const SuppliersTable = () => {
 				title: "",
 				key: "action",
 				dataIndex: "action",
-				width: 100,
+				width: 120,
 				render: (_, record) => {
 					return (
 						<TableActionsWrapper key={record?.id}>
+							<Eye
+								color={"#1677ff"}
+								onClick={() =>
+									setSearchParams((params) => {
+										if (!record?.id) return params
+										params.set("supplier_id", record?.id)
+										return params
+									})
+								}
+							/>
 							<Pencil
 								color={"#1677ff"}
 								onClick={() =>

--- a/src/pages/Suppliers/List/index.tsx
+++ b/src/pages/Suppliers/List/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from "@/components/PageHeader"
 import { NewSupplier } from "@/pages/Suppliers/List/NewSupplier"
+import { SupplierDetails } from "@/pages/Suppliers/List/SupplierDetails"
 import { SuppliersTable } from "@/pages/Suppliers/List/Table"
 import { Button, Drawer } from "antd"
 import { FolderPlus } from "phosphor-react"
@@ -44,6 +45,7 @@ export const SuppliersList = () => {
 			>
 				<NewSupplier />
 			</Drawer>
+			<SupplierDetails />
 		</div>
 	)
 }

--- a/src/pages/Suppliers/index.tsx
+++ b/src/pages/Suppliers/index.tsx
@@ -1,5 +1,6 @@
 import Title from "@/components/Title"
 import TitlePage from "@/components/TitlePage"
+import { AddressForm } from "@/pages/Suppliers/AddressForm"
 import { SuppliersList } from "@/pages/Suppliers/List"
 import { PageContainer } from "@/style/global"
 
@@ -11,6 +12,7 @@ const Suppliers = () => {
 			<PageContainer>
 				<SuppliersList />
 			</PageContainer>
+			<AddressForm />
 		</>
 	)
 }

--- a/src/services/adressServices.ts
+++ b/src/services/adressServices.ts
@@ -1,0 +1,32 @@
+import { isValidCEP } from "@/helpers/general"
+import { useQuery } from "@tanstack/react-query"
+import axios from "axios"
+
+type AddressViaCep = {
+	bairro: string
+	cep: string
+	estado: string
+	ddd: string
+	complemento: string
+	localidade: string
+	logradouro: string
+	regiao: string
+	uf: string
+}
+
+export const useGetAddressByCEP = (cep: string) => {
+	const url = `https://viacep.com.br/ws/${cep}/json/`
+
+	const query = useQuery({
+		queryKey: [url],
+		queryFn: () => axios.get<AddressViaCep>(url),
+		enabled: isValidCEP(cep),
+	})
+
+	return {
+		data: query.data?.data,
+		isLoading: query.isLoading,
+		error: query.error,
+		query,
+	}
+}

--- a/src/services/adressServices.ts
+++ b/src/services/adressServices.ts
@@ -14,6 +14,22 @@ type AddressViaCep = {
 	uf: string
 }
 
+type Uf = {
+	id: string
+	nome: string
+	sigla: string
+	regiao: {
+		id: string
+		nome: string
+		sigla: string
+	}
+}
+
+type City = {
+	id: string
+	nome: string
+}
+
 export const useGetAddressByCEP = (cep: string) => {
 	const url = `https://viacep.com.br/ws/${cep}/json/`
 
@@ -21,6 +37,36 @@ export const useGetAddressByCEP = (cep: string) => {
 		queryKey: [url],
 		queryFn: () => axios.get<AddressViaCep>(url),
 		enabled: isValidCEP(cep),
+	})
+
+	return {
+		data: query.data?.data,
+		isLoading: query.isLoading,
+		error: query.error,
+		query,
+	}
+}
+
+export const useGetUFs = () => {
+	const url = "https://servicodados.ibge.gov.br/api/v1/localidades/estados"
+	const query = useQuery({
+		queryKey: [url],
+		queryFn: () => axios.get<Uf[]>(url),
+	})
+
+	return {
+		data: query.data?.data,
+		isLoading: query.isLoading,
+		error: query.error,
+		query,
+	}
+}
+
+export const useGetCitiesByUF = (uf: string) => {
+	const url = `https://servicodados.ibge.gov.br/api/v1/localidades/estados/${uf}/municipios`
+	const query = useQuery({
+		queryKey: [url],
+		queryFn: () => axios.get<City[]>(url),
 	})
 
 	return {

--- a/src/services/useGetSuppliers.ts
+++ b/src/services/useGetSuppliers.ts
@@ -5,10 +5,10 @@ import { useQuery } from "@tanstack/react-query"
 
 type SuppliersBody = {
 	name: string
-	cnpj: string
-	legalName: string
-	ERPcode: string
-	code: string
+	cnpj?: string
+	legalName?: string
+	ERPCode?: string
+	code?: string
 	email?: string
 	fone?: string
 	users?: string[]
@@ -16,10 +16,16 @@ type SuppliersBody = {
 export type Suppliers = {
 	ERPCode: string
 	active: boolean
-	address: {
-		addressTypeId: string
+	addresses?: {
 		id: string
-	}
+		lograd?: string
+		number?: string
+		complement?: string
+		district?: string
+		city?: string
+		state?: string
+		zipcode?: string
+	}[]
 	cnpj: string
 	code: string
 	createdAt: string

--- a/src/services/useGetSuppliers.ts
+++ b/src/services/useGetSuppliers.ts
@@ -87,7 +87,37 @@ export const useGetSuppliersActions = () => {
 		)
 	}
 
-	return { createSupplier, deleteSupplier, updateSupplier, addAddress }
+	const deleteAddress = async (supplierId: string, addressId: string) => {
+		return await ApiInstance.delete(
+			`/suppliers/${supplierId}/addresses/${addressId}/delete`,
+			{
+				headers,
+			},
+		)
+	}
+
+	const editAddress = async (
+		supplierId: string,
+		addressId: string,
+		data: Partial<AddressType>,
+	) => {
+		return await ApiInstance.patch(
+			`/suppliers/${supplierId}/addresses/${addressId}/edit`,
+			data,
+			{
+				headers,
+			},
+		)
+	}
+
+	return {
+		createSupplier,
+		deleteSupplier,
+		updateSupplier,
+		addAddress,
+		deleteAddress,
+		editAddress,
+	}
 }
 
 export const useGetSuppliers = () => {

--- a/src/services/useGetSuppliers.ts
+++ b/src/services/useGetSuppliers.ts
@@ -13,19 +13,24 @@ type SuppliersBody = {
 	fone?: string
 	users?: string[]
 }
+
+type AddressType = {
+	id: string
+	lograd?: string
+	number?: string
+	complement?: string
+	district?: string
+	city?: string
+	state?: string
+	zipcode?: string
+	addressType: {
+		description: string
+	}
+}
 export type Suppliers = {
 	ERPcode: string
 	active: boolean
-	addresses?: {
-		id: string
-		lograd?: string
-		number?: string
-		complement?: string
-		district?: string
-		city?: string
-		state?: string
-		zipcode?: string
-	}[]
+	addresses?: AddressType[]
 	cnpj: string
 	code: string
 	createdAt: string

--- a/src/services/useGetSuppliers.ts
+++ b/src/services/useGetSuppliers.ts
@@ -14,7 +14,7 @@ type SuppliersBody = {
 	users?: string[]
 }
 
-type AddressType = {
+export type AddressType = {
 	id: string
 	lograd?: string
 	number?: string
@@ -23,8 +23,8 @@ type AddressType = {
 	city?: string
 	state?: string
 	zipcode?: string
-	addressType: {
-		description: string
+	addressType?: {
+		description?: string
 	}
 }
 export type Suppliers = {
@@ -77,7 +77,17 @@ export const useGetSuppliersActions = () => {
 		)
 	}
 
-	return { createSupplier, deleteSupplier, updateSupplier }
+	const addAddress = async (supplierId: string, data: Partial<AddressType>) => {
+		return await ApiInstance.post(
+			`/suppliers/${supplierId}/addresses/new`,
+			data,
+			{
+				headers,
+			},
+		)
+	}
+
+	return { createSupplier, deleteSupplier, updateSupplier, addAddress }
 }
 
 export const useGetSuppliers = () => {

--- a/src/services/useGetSuppliers.ts
+++ b/src/services/useGetSuppliers.ts
@@ -7,14 +7,14 @@ type SuppliersBody = {
 	name: string
 	cnpj?: string
 	legalName?: string
-	ERPCode?: string
+	ERPcode?: string
 	code?: string
 	email?: string
 	fone?: string
 	users?: string[]
 }
 export type Suppliers = {
-	ERPCode: string
+	ERPcode: string
 	active: boolean
 	addresses?: {
 		id: string


### PR DESCRIPTION
# ✨ Novidades

Adicionamos várias melhorias significativas na gestão de endereços para fornecedores, implementando funcionalidades essenciais e refinando a experiência do usuário. Confira abaixo os detalhes das mudanças:

## 🌟 Implementações Recentes 

### ✏️ Melhorias na Gestão de Endereços
- Implementado suporte para edição e exclusão de endereços:
  - Adicionado hook `useState` para gerenciar o estado de exclusão.
  - Introduzido método `deleteAddress` em `useGetSuppliersActions`.
  - Refatorado `handleDeleteAddress` para utilizar `deleteAddress`.

### 📝 Adição de Endereços para Fornecedores
- Funcionalidade de criação e busca por estado e cidade:
  - Função `addAddress` no hook `useGetSuppliers`.
  - Ajuste no tipo `AddressType` para permitir campos opcionais.
  - Funções `useGetUFs` e `useGetCitiesByUF` para buscar dados da API do IBGE.

### 🛠️ Integração com ViaCEP
- Novo formulário de endereços integrado com ViaCEP:
  - Serviço `adressServices` para buscar endereço por CEP.
  - Criação de `AddressForm` com validações e máscaras.

### ✂️ Edição e Exclusão de Endereços
- Adicionadas funcionalidades de edição e exclusão:
  - Componente `AddressWrapper` com styled-components.
  - Exibição de endereços em formato de cartões com botões de edição e exclusão.

### 🚀 Padronização de Nomenclatura
- Correção de inconsistências:
  - Padronização do campo "ERPcode" em todos os arquivos relevantes.
  - Atualização de declarações de tipagem e validações no arquivo `useGetSuppliers.ts`.

### 🖥️ Visualização Detalhada de Fornecedores
- Criação da interface de detalhes:
  - Componente `SupplierDetails` para visualização detalhada.
  - Modificações no serviço `useGetSuppliers` para campos opcionais.