### PR TITLE
CRUD de tipos de produtos

### DIFF
--- a/src/components/Menu/consts.tsx
+++ b/src/components/Menu/consts.tsx
@@ -8,6 +8,7 @@ import {
 	Kanban,
 	Package,
 	ShoppingCart,
+	ShoppingCartSimple,
 	SignOut,
 	Truck,
 	User,
@@ -76,6 +77,13 @@ export const defaultMenuItems = [
 				key: "/configuracoes/usuarios",
 				label: "Usuário",
 				icon: <User weight="regular" size={24} color={"#272F51"} />,
+			},
+			{
+				key: "/configuracoes/tipos-de-produtos",
+				label: "Tipos de produto",
+				icon: (
+					<ShoppingCartSimple weight="regular" size={24} color={"#272F51"} />
+				),
 			},
 		],
 	},

--- a/src/components/Menu/useGetMenuItems.tsx
+++ b/src/components/Menu/useGetMenuItems.tsx
@@ -1,5 +1,6 @@
 import { defaultMenuItems } from "@/components/Menu/consts"
 import type { MenuProps } from "antd"
+import type React from "react"
 
 export type MenuItem = Required<MenuProps>["items"][number]
 

--- a/src/pages/Products/ProductForm/index.tsx
+++ b/src/pages/Products/ProductForm/index.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/pages/Products/ProductForm/schema"
 import { type ErrorExtended, parseError } from "@/services/api"
 import {
+	type ProductBody,
 	useGetProducts,
 	useGetProductsActions,
 	useGetProductsTypes,
@@ -70,10 +71,28 @@ export const ProductForm = () => {
 	const handleSubmit = async (data: ProductsSchemaType) => {
 		setIsLoading(true)
 
+		const body: ProductBody = {
+			code: data.code,
+			description: data.description,
+			additionalDescription: data.additionalDescription,
+			stockUnit: data.stockUnit,
+			ERPCode: data.ERPCode,
+			productType: data.productType,
+			productGroup: data.productGroup,
+		}
+
+		const keys = Object.keys(body) as (keyof ProductBody)[]
+
+		for (const key of keys) {
+			if (!body[key]?.length) {
+				delete body[key]
+			}
+		}
+
 		try {
 			isEditing
-				? await updateProduct(editProductId, data)
-				: await createProduct(data)
+				? await updateProduct(editProductId, body)
+				: await createProduct(body)
 
 			await productsQuery.refetch()
 			showNotification({

--- a/src/pages/Settings/ProductsType/ProductTypeForm/index.tsx
+++ b/src/pages/Settings/ProductsType/ProductTypeForm/index.tsx
@@ -1,0 +1,136 @@
+import { NewInput } from "@/components/NewInput"
+import { useGetNotification } from "@/hooks/useGetNotification"
+import {
+	EMPTY_PRODUCTS_TYPE,
+	type ProductTypeSchemaType,
+	productTypeSchema,
+} from "@/pages/Settings/ProductsType/ProductTypeForm/schema"
+import { type ErrorExtended, parseError } from "@/services/api"
+import {
+	useGetProductsTypes,
+	useGetProductsTypesActions,
+} from "@/services/productsService"
+import { FormFooter, FormStyled } from "@/style/global"
+import { yupResolver } from "@hookform/resolvers/yup"
+import { Button, Drawer } from "antd"
+import { useMemo, useState } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { useSearchParams } from "react-router-dom"
+
+export const ProductTypeForm = () => {
+	const [searchParams, setSearchParams] = useSearchParams()
+	const [isLoading, setIsLoading] = useState(false)
+	const isCreatingNew = searchParams.get("action") === "create_product_type"
+	const typeId = searchParams.get("product_type_id")
+	const { data: productsTypes, query: productsTypesQuery } =
+		useGetProductsTypes()
+	const { createProductType, updateProductType } = useGetProductsTypesActions()
+	const { showNotification } = useGetNotification()
+
+	const isDrawerOpen = isCreatingNew || !!typeId
+
+	const handleCancel = () => {
+		setSearchParams((params) => {
+			params.delete("action")
+			params.delete("product_type_id")
+			return params
+		})
+	}
+
+	const initialValues = useMemo(() => {
+		if (!isCreatingNew && !typeId) {
+			return {
+				...EMPTY_PRODUCTS_TYPE,
+				id: crypto.randomUUID(),
+			}
+		}
+		const productType = productsTypes?.productTypes.find(
+			(productType) => productType.id === typeId,
+		)
+		if (!productType) return EMPTY_PRODUCTS_TYPE
+		return {
+			description: productType.description,
+			id: productType.id,
+		}
+	}, [typeId, isCreatingNew, productsTypes])
+
+	const onSubmit = async (data: ProductTypeSchemaType) => {
+		setIsLoading(true)
+		const body = {
+			description: data.description,
+		}
+		try {
+			typeId
+				? await updateProductType(typeId, body)
+				: await createProductType(body)
+			await productsTypesQuery.refetch()
+			showNotification({
+				type: "SUCCESS",
+				message: isCreatingNew
+					? "Tipo de produto criado com sucesso"
+					: "Tipo de produto atualizado com sucesso",
+				description: "",
+			})
+			handleCancel()
+		} catch (err) {
+			const parsedError = parseError(err as ErrorExtended)
+			showNotification({
+				type: "ERROR",
+				message: isCreatingNew
+					? "Erro ao criar tipo de produto"
+					: "Erro ao atualizar tipo de produto",
+				description: parsedError ?? "Verifique seus dados e tente novamente",
+			})
+		} finally {
+			setIsLoading(false)
+		}
+	}
+
+	const methods = useForm<ProductTypeSchemaType>({
+		resolver: yupResolver(productTypeSchema),
+		values: initialValues,
+		mode: "all",
+	})
+
+	return (
+		<Drawer
+			title={isCreatingNew ? "Novo tipo de produto" : "Editar tipo de produto"}
+			open={isDrawerOpen}
+			width={600}
+			footer={false}
+			onClose={handleCancel}
+		>
+			<FormStyled onSubmit={methods.handleSubmit(onSubmit)}>
+				<Controller
+					name={"description"}
+					control={methods.control}
+					render={({ field }) => (
+						<NewInput
+							required
+							label={"Descrição"}
+							placeholder={"Descrição do tipo de produto"}
+							errorMessage={methods.formState.errors.description?.message}
+							{...field}
+						/>
+					)}
+				/>
+				<FormFooter>
+					<Button onClick={handleCancel}>Cancelar</Button>
+					<Button
+						className="button2"
+						htmlType="submit"
+						type="primary"
+						disabled={
+							!methods.formState.isValid ||
+							productsTypesQuery.isLoading ||
+							isLoading
+						}
+						loading={isLoading}
+					>
+						Salvar
+					</Button>
+				</FormFooter>
+			</FormStyled>
+		</Drawer>
+	)
+}

--- a/src/pages/Settings/ProductsType/ProductTypeForm/schema.ts
+++ b/src/pages/Settings/ProductsType/ProductTypeForm/schema.ts
@@ -1,0 +1,13 @@
+import * as yup from "yup"
+
+export const productTypeSchema = yup.object().shape({
+	description: yup.string().required("Campo obrigatório"),
+	id: yup.string(),
+})
+
+export type ProductTypeSchemaType = yup.InferType<typeof productTypeSchema>
+
+export const EMPTY_PRODUCTS_TYPE: ProductTypeSchemaType = {
+	description: "",
+	id: "",
+}

--- a/src/pages/Settings/ProductsType/index.tsx
+++ b/src/pages/Settings/ProductsType/index.tsx
@@ -1,0 +1,42 @@
+import { PageHeader } from "@/components/PageHeader"
+import Title from "@/components/Title"
+import TitlePage from "@/components/TitlePage"
+import { ProductsTypeList } from "@/pages/Settings/ProductsType/list"
+import { Container } from "@/pages/Settings/Users/styles"
+import { Button } from "antd"
+import { CirclesThreePlus } from "phosphor-react"
+import { useSearchParams } from "react-router-dom"
+
+export const ManageProductsType = () => {
+	const [_, setSearchParams] = useSearchParams()
+
+	const handleCreateProductType = () => {
+		setSearchParams((params) => {
+			params.set("action", "create_product")
+			return params
+		})
+	}
+
+	return (
+		<>
+			<TitlePage title="Configurações de tipos de produto" />
+			<Title>Configurações de tipos de produto</Title>
+			<Container>
+				<PageHeader
+					searchQuery={"productType"}
+					placeholder={"Buscar tipo de produto"}
+					rightContent={
+						<Button
+							type="primary"
+							icon={<CirclesThreePlus size={20} />}
+							onClick={handleCreateProductType}
+						>
+							Novo tipo de produto
+						</Button>
+					}
+				/>
+				<ProductsTypeList />
+			</Container>
+		</>
+	)
+}

--- a/src/pages/Settings/ProductsType/index.tsx
+++ b/src/pages/Settings/ProductsType/index.tsx
@@ -1,6 +1,7 @@
 import { PageHeader } from "@/components/PageHeader"
 import Title from "@/components/Title"
 import TitlePage from "@/components/TitlePage"
+import { ProductTypeForm } from "@/pages/Settings/ProductsType/ProductTypeForm"
 import { ProductsTypeList } from "@/pages/Settings/ProductsType/list"
 import { Container } from "@/pages/Settings/Users/styles"
 import { Button } from "antd"
@@ -12,7 +13,7 @@ export const ManageProductsType = () => {
 
 	const handleCreateProductType = () => {
 		setSearchParams((params) => {
-			params.set("action", "create_product")
+			params.set("action", "create_product_type")
 			return params
 		})
 	}
@@ -36,6 +37,7 @@ export const ManageProductsType = () => {
 					}
 				/>
 				<ProductsTypeList />
+				<ProductTypeForm />
 			</Container>
 		</>
 	)

--- a/src/pages/Settings/ProductsType/list/index.tsx
+++ b/src/pages/Settings/ProductsType/list/index.tsx
@@ -1,24 +1,51 @@
+import { useGetNotification } from "@/hooks/useGetNotification"
+import { type ErrorExtended, parseError } from "@/services/api"
 import {
 	type GenericEntity,
 	useGetProductsTypes,
+	useGetProductsTypesActions,
 } from "@/services/productsService"
 import { TableActionsWrapper, TableWrapper } from "@/style/global"
 import { Popconfirm, Table, type TableColumnsType } from "antd"
 import { Pencil, Trash } from "phosphor-react"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 
 export const ProductsTypeList = () => {
 	const { data, isLoading, query: productsTypesQuery } = useGetProductsTypes()
-	const [searchParams] = useSearchParams()
+	const [searchParams, setSearchParams] = useSearchParams()
+	const [isDeleting, setIsDeleting] = useState(false)
+	const { deleteProductType } = useGetProductsTypesActions()
 	const typeSearchQuery = searchParams.get("productType")
+	const { showNotification } = useGetNotification()
 
-	const handleDelete = (id: string) => {
-		console.log(id)
+	const handleDelete = async (id: string) => {
+		setIsDeleting(true)
+		try {
+			await deleteProductType(id)
+			await productsTypesQuery.refetch()
+			showNotification({
+				type: "SUCCESS",
+				message: "Tipo de produto deletado com sucesso",
+				description: "",
+			})
+		} catch (err) {
+			const parsedError = parseError(err as ErrorExtended)
+			showNotification({
+				type: "ERROR",
+				message: parsedError ?? "Erro ao deletar tipo de produto",
+				description: "Verifique seus dados e tente novamente",
+			})
+		} finally {
+			setIsDeleting(false)
+		}
 	}
 
 	const handleEdit = (id: string) => {
-		console.log(id)
+		setSearchParams((params) => {
+			params.set("product_type_id", id)
+			return params
+		})
 	}
 
 	const columns: TableColumnsType<GenericEntity> = [
@@ -54,7 +81,7 @@ export const ProductsTypeList = () => {
 							okText={"Deletar"}
 							cancelText={"Cancelar"}
 							placement={"topLeft"}
-							// okButtonProps={{ loading: isDeleting }}
+							okButtonProps={{ loading: isDeleting }}
 						>
 							<Trash className={"delete"} />
 						</Popconfirm>

--- a/src/pages/Settings/ProductsType/list/index.tsx
+++ b/src/pages/Settings/ProductsType/list/index.tsx
@@ -1,0 +1,86 @@
+import {
+	type GenericEntity,
+	useGetProductsTypes,
+} from "@/services/productsService"
+import { TableActionsWrapper, TableWrapper } from "@/style/global"
+import { Popconfirm, Table, type TableColumnsType } from "antd"
+import { Pencil, Trash } from "phosphor-react"
+import { useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
+
+export const ProductsTypeList = () => {
+	const { data, isLoading, query: productsTypesQuery } = useGetProductsTypes()
+	const [searchParams] = useSearchParams()
+	const typeSearchQuery = searchParams.get("productType")
+
+	const handleDelete = (id: string) => {
+		console.log(id)
+	}
+
+	const handleEdit = (id: string) => {
+		console.log(id)
+	}
+
+	const columns: TableColumnsType<GenericEntity> = [
+		{
+			title: "Descrição",
+			dataIndex: "description",
+			key: "description",
+			render: (_, record) => record?.description,
+		},
+		{
+			title: "id",
+			dataIndex: "id",
+			key: "id",
+			render: (_, record) => record?.id,
+		},
+
+		{
+			title: "",
+			dataIndex: "action",
+			key: "action",
+			width: 100,
+			render: (_, record) => {
+				return (
+					<TableActionsWrapper key={record?.id}>
+						<Pencil
+							color={"#1677ff"}
+							onClick={() => handleEdit(record?.id ?? "")}
+						/>
+						<Popconfirm
+							key={record?.id}
+							title={`Tem certeza que deseja excluir o produto ${record?.description ?? ""}?`}
+							onConfirm={() => handleDelete(record?.id ?? "")}
+							okText={"Deletar"}
+							cancelText={"Cancelar"}
+							placement={"topLeft"}
+							// okButtonProps={{ loading: isDeleting }}
+						>
+							<Trash className={"delete"} />
+						</Popconfirm>
+					</TableActionsWrapper>
+				)
+			},
+		},
+	]
+
+	const dataToDisplay: GenericEntity[] = useMemo(() => {
+		if (!data?.productTypes) return []
+		if (!typeSearchQuery) return data.productTypes
+		return data.productTypes.filter((product) =>
+			product.description.toLowerCase().includes(typeSearchQuery.toLowerCase()),
+		)
+	}, [data, typeSearchQuery])
+
+	return (
+		<TableWrapper>
+			<Table
+				columns={columns}
+				dataSource={dataToDisplay}
+				virtual={true}
+				loading={isLoading}
+				pagination={false}
+			/>
+		</TableWrapper>
+	)
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,7 @@ import Orders from "@/pages/Orders"
 import Products from "@/pages/Products"
 import ResetPassword from "@/pages/ResetPassword"
 import Section from "@/pages/Section"
+import { ManageProductsType } from "@/pages/Settings/ProductsType"
 import Profile from "@/pages/Settings/Profile"
 import Users from "@/pages/Settings/Users"
 import UserDetails from "@/pages/Settings/Users/UserDetails"
@@ -91,7 +92,6 @@ export const router = createBrowserRouter([
 				children: [
 					{
 						path: "usuarios",
-
 						children: [
 							{
 								index: true,
@@ -105,7 +105,6 @@ export const router = createBrowserRouter([
 					},
 					{
 						path: "perfil",
-
 						children: [
 							{ index: true, element: <Profile /> },
 							{
@@ -117,6 +116,15 @@ export const router = createBrowserRouter([
 								element: (
 									<ProfileForm action="duplicate" title="Duplicar Perfil" />
 								),
+							},
+						],
+					},
+					{
+						path: "tipos-de-produtos",
+						children: [
+							{
+								index: true,
+								element: <ManageProductsType />,
 							},
 						],
 					},

--- a/src/services/productsService.ts
+++ b/src/services/productsService.ts
@@ -5,7 +5,7 @@ import { useUserStore } from "@/stores/User/useUserStore"
 import type { PaginatedResponse } from "@/types/rota"
 import { useQuery } from "@tanstack/react-query"
 
-type GenericEntity = {
+export type GenericEntity = {
 	id: string
 	description: string
 }
@@ -45,7 +45,7 @@ type ProductResponse = {
 	products: ProductType[]
 }
 
-type ProductBody = {
+export type ProductBody = {
 	code: string
 	description: string
 	additionalDescription?: string
@@ -95,7 +95,7 @@ export const useGetProductsActions = () => {
 	}
 
 	const updateProduct = async (id: string, data: Partial<ProductBody>) => {
-		const url = `/products/${id}/update`
+		const url = `/products/${id}/edit`
 		return await ApiInstance.patch<Partial<ProductBody>, ProductType>(
 			url,
 			data,

--- a/src/services/productsService.ts
+++ b/src/services/productsService.ts
@@ -164,7 +164,7 @@ export const useGetProductsTypesActions = () => {
 		id: string,
 		data: Partial<GenericEntity>,
 	) => {
-		const url = `/products/types/${id}/update`
+		const url = `/products/types/${id}/edit`
 		return await ApiInstance.patch<Partial<GenericEntity>, GenericEntity>(
 			url,
 			data,


### PR DESCRIPTION
# ✨ Novidades

## Descrição Geral

Adicionamos funcionalidades para gerenciar tipos de produtos, facilitando a criação, edição, exclusão e listagem.

## 🚀 Implementações Recentes

### 🗓️ feat(configurações): adicionar gerenciamento de tipos de produtos
Adicionamos uma nova página para listar tipos de produtos com integração à API. Agora é possível buscar, editar e excluir tipos de produtos. O menu lateral foi ajustado para incluir essa funcionalidade. Criamos o componente ManageProductsType e melhoramos os serviços e interfaces.

### 🗓️ feat: adicionar formulário de criação/edição e funcionalidade de exclusão
Implementamos o ProductTypeForm para criar e editar tipos de produto, com validação e notificações. A lista de tipos de produtos é atualizada automaticamente após alterações, e integramos a funcionalidade de exclusão com feedback visual.