### PR TITLE
Exibir associações de tipos de produtos e desabilitar o delete

### DIFF
--- a/src/services/productsService.ts
+++ b/src/services/productsService.ts
@@ -112,8 +112,14 @@ export const useGetProductsActions = () => {
 	}
 }
 
+export type ProductsType = {
+	description: string
+	id: string
+	products: number
+}
+
 type ProductsTypesResponse = {
-	productTypes: GenericEntity[]
+	productTypes: ProductsType[]
 }
 
 export const useGetProductsTypes = () => {

--- a/src/style/global.tsx
+++ b/src/style/global.tsx
@@ -90,14 +90,6 @@ export default createGlobalStyle`
 	.delete {
 		color: var(--red-500);
 	}
-
-
-	// @media screen and (min-width: 920px) {
-    //   body {
-    //     padding-top: 70px;
-    //   }
-
-    // }
 `
 
 export const spacing = {


### PR DESCRIPTION
# 🚀 Novidades

## Descrição Geral
Esta atualização inclui a adição de uma nova coluna que exibe a quantidade de produtos associados, além de melhorias na listagem e ações dos tipos de produtos. Tipos de produtos com itens associados não podem ser excluídos.

## Mudanças
### 🆕 - Adição de nova coluna
- Adicionada nova coluna "Produtos associados" com tag colorida.
- Ajustada tipagem das colunas da tabela para usar ProductsType.

### 🎨 - Melhorias na listagem e ações
- ProdutosType define estrutura com descrição, id e quantidade de produtos.
- Adicionada ordenação nas colunas de "Descrição" e "Produtos associados".
- Alteração do comportamento do ícone de exclusão para tipos com produtos associados.
- Tooltip para indicar que tipos de produtos associados não podem ser excluídos.
- Uso de const para verificar se um tipo de produto está em modo somente leitura.

### 🐛 - Correções
- Correção de renderização dinâmica do Popconfirm e ícone de exclusão.
- Remoção de comentários desnecessários e entradas obsoletas no código.