### PR TITLE
Unidades de medidas

### DIFF
--- a/src/components/Menu/consts.tsx
+++ b/src/components/Menu/consts.tsx
@@ -7,6 +7,7 @@ import {
 	House,
 	Kanban,
 	Package,
+	Scales,
 	ShoppingCart,
 	ShoppingCartSimple,
 	SignOut,
@@ -84,6 +85,11 @@ export const defaultMenuItems = [
 				icon: (
 					<ShoppingCartSimple weight="regular" size={24} color={"#272F51"} />
 				),
+			},
+			{
+				key: "/configuracoes/unidades-de-medida",
+				label: "Un de medida",
+				icon: <Scales weight="regular" size={24} color={"#272F51"}/>,
 			},
 		],
 	},

--- a/src/pages/Products/List/index.tsx
+++ b/src/pages/Products/List/index.tsx
@@ -12,7 +12,7 @@ import {
 	TableActionsWrapper,
 	TableWrapper,
 } from "@/style/global"
-import { Popconfirm, Table, type TableColumnsType } from "antd"
+import { Popconfirm, Table, type TableColumnsType, Tag } from "antd"
 import { Pencil, Trash } from "phosphor-react"
 import { useMemo, useState } from "react"
 import { useSearchParams } from "react-router-dom"
@@ -91,6 +91,14 @@ export const ProductsList = () => {
 			dataIndex: "productType",
 			key: "productType",
 			render: (_, record) => getTextValue(record?.productType?.description),
+		},
+		{
+			title: "Unidade de medida",
+			dataIndex: "stockUnit",
+			key: "stockUnit",
+			render: (_, record) => (
+				<Tag>{getTextValue(record?.stockUnit?.abrev)}</Tag>
+			),
 		},
 		{
 			title: "",

--- a/src/pages/Products/ProductForm/index.tsx
+++ b/src/pages/Products/ProductForm/index.tsx
@@ -11,6 +11,8 @@ import {
 	type ProductBody,
 	useGetProducts,
 	useGetProductsActions,
+	useGetProductsMesureUnits,
+	useGetProductsMesureUnitsActions,
 	useGetProductsTypes,
 	useGetProductsTypesActions,
 } from "@/services/productsService"
@@ -30,6 +32,9 @@ export const ProductForm = () => {
 	const { data: productsTypes, query: productsTypesQuery } =
 		useGetProductsTypes()
 	const { createProductType } = useGetProductsTypesActions()
+	const { data: mesureUnits, query: mesureUnitsQuery } =
+		useGetProductsMesureUnits()
+	const { createProductMesureUnit } = useGetProductsMesureUnitsActions()
 
 	const isCreatingNew = searchParams.get("action") === "create_product"
 	const editProductId = searchParams.get("edit_product_id")
@@ -124,6 +129,14 @@ export const ProductForm = () => {
 		await productsTypesQuery.refetch()
 	}
 
+	const handleAddMesureUnit = async (value: string) => {
+		await createProductMesureUnit({
+			description: "",
+			abrev: value,
+		})
+		await mesureUnitsQuery.refetch()
+	}
+
 	return (
 		<>
 			<Drawer
@@ -181,22 +194,15 @@ export const ProductForm = () => {
 						name={"stockUnit"}
 						control={methods.control}
 						render={({ field }) => (
-							// <NewInput
-							// 	required
-							// 	label={"Unidade de estoque"}
-							// 	placeholder={"Unidade de estoque do produto"}
-							// 	errorMessage={methods.formState.errors.stockUnit?.message}
-							// 	{...field}
-							// />
 							<DropDownWithCreate
 								required
 								errorMessage={methods.formState.errors.stockUnit?.message}
 								label={"Unidade de estoque"}
 								placeholder={"Unidade de estoque do produto"}
 								options={
-									productsTypes?.productTypes?.map((productType) => ({
-										label: productType.description,
-										value: productType.id,
+									mesureUnits?.units?.map((unit) => ({
+										label: unit.abrev,
+										value: unit.id,
 									})) ?? []
 								}
 								currentValue={methods.watch("stockUnitId")}
@@ -208,7 +214,7 @@ export const ProductForm = () => {
 								}}
 								creation={{
 									actionLabel: "Adicionar",
-									onNewValue: handleAddProductType,
+									onNewValue: handleAddMesureUnit,
 									placeholder: "Unidade de estoque",
 									isLoading: productsTypesQuery.isLoading,
 									isDisabled: productsTypesQuery.isLoading,

--- a/src/pages/Settings/MesureUnits/index.tsx
+++ b/src/pages/Settings/MesureUnits/index.tsx
@@ -1,0 +1,44 @@
+import { PageHeader } from "@/components/PageHeader"
+import Title from "@/components/Title"
+import TitlePage from "@/components/TitlePage"
+import { MesureUnitsList } from "@/pages/Settings/MesureUnits/list"
+import { MesureUnitForm } from "@/pages/Settings/MesureUnits/mesureUnitForm"
+import { Container } from "@/pages/Settings/Users/styles"
+import { Button } from "antd"
+import { CirclesThreePlus } from "phosphor-react"
+import { useSearchParams } from "react-router-dom"
+
+export const ManageMesureUnits = () => {
+	const [_, setSearchParams] = useSearchParams()
+
+	const handleCreateMesureUnit = () => {
+		setSearchParams((params) => {
+			params.set("action", "create_mesure_unit")
+			return params
+		})
+	}
+
+	return (
+		<>
+			<TitlePage title="Configurações de unidades de medida" />
+			<Title>Configurações de unidades de medida</Title>
+			<Container>
+				<PageHeader
+					searchQuery={"mesureUnit"}
+					placeholder={"Buscar unidade de medida"}
+					rightContent={
+						<Button
+							type="primary"
+							icon={<CirclesThreePlus size={20} />}
+							onClick={handleCreateMesureUnit}
+						>
+							Novo unidade de medida
+						</Button>
+					}
+				/>
+				<MesureUnitsList />
+				<MesureUnitForm />
+			</Container>
+		</>
+	)
+}

--- a/src/pages/Settings/MesureUnits/list/index.tsx
+++ b/src/pages/Settings/MesureUnits/list/index.tsx
@@ -1,0 +1,146 @@
+import { useGetNotification } from "@/hooks/useGetNotification"
+import { useHandlePagination } from "@/hooks/useHandlePagination"
+import { type ErrorExtended, parseError } from "@/services/api"
+import {
+	type MeasureUnit,
+	useGetProductsMesureUnits,
+	useGetProductsMesureUnitsActions,
+} from "@/services/productsService"
+import {
+	InfoAndSubInfoWrapper,
+	TableActionsWrapper,
+	TableWrapper,
+} from "@/style/global"
+import { Popconfirm, Table, type TableColumnsType } from "antd"
+import { Pencil, Trash } from "phosphor-react"
+import React, { useMemo, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+
+export const MesureUnitsList = () => {
+	const {
+		data,
+		isLoading,
+		query: mesureUnitsQuery,
+	} = useGetProductsMesureUnits()
+	const [searchParams, setSearchParams] = useSearchParams()
+	const [isDeleting, setIsDeleting] = useState(false)
+	const { showNotification } = useGetNotification()
+	const { deleteProductMesureUnit } = useGetProductsMesureUnitsActions()
+	const { pageSize, handlePagination, handleChangePageSize } =
+		useHandlePagination()
+
+	const mesureUnitId = searchParams.get("mesure_unit_id")
+	const mesureUnitSearchQuery = searchParams.get("mesureUnit")
+
+	const handleDelete = async (id: string) => {
+		setIsDeleting(true)
+		try {
+			await deleteProductMesureUnit(id)
+			await mesureUnitsQuery.refetch()
+			showNotification({
+				type: "SUCCESS",
+				message: "Unidade de medida deletado com sucesso",
+				description: "",
+			})
+		} catch (err) {
+			const parsedError = parseError(err as ErrorExtended)
+			showNotification({
+				type: "ERROR",
+				message: parsedError ?? "Erro ao deletar unidade de medida",
+				description: "Verifique seus dados e tente novamente",
+			})
+		} finally {
+			setIsDeleting(false)
+		}
+	}
+
+	const handleEdit = (id: string) => {
+		setSearchParams((params) => {
+			params.set("mesure_unit_id", id)
+			return params
+		})
+	}
+
+	const columns: TableColumnsType<MeasureUnit> = [
+		{
+			title: "Unidade de medida",
+			dataIndex: "abrev",
+			key: "abrev",
+			sorter: (a, b) => a?.abrev.localeCompare(b?.abrev ?? "") ?? 0,
+			sortDirections: ["descend", "ascend"],
+			render: (_, record) => {
+				return (
+					<InfoAndSubInfoWrapper key={record.id}>
+						<p>{record.abrev}</p>
+						<i>{record.description}</i>
+					</InfoAndSubInfoWrapper>
+				)
+			},
+		},
+		{
+			title: "id",
+			dataIndex: "id",
+			key: "id",
+			render: (_, record) => record?.id,
+		},
+		{
+			title: "",
+			dataIndex: "action",
+			key: "action",
+			width: 100,
+			render: (_, record) => {
+				return (
+					<TableActionsWrapper key={record?.id}>
+						<Pencil
+							color={"#1677ff"}
+							onClick={() => handleEdit(record?.id ?? "")}
+						/>
+						<Popconfirm
+							key={record?.id}
+							title={`Tem certeza que deseja excluir o produto ${record?.description ?? ""}?`}
+							onConfirm={() => handleDelete(record?.id ?? "")}
+							okText={"Deletar"}
+							cancelText={"Cancelar"}
+							placement={"topLeft"}
+							okButtonProps={{ loading: isDeleting }}
+						>
+							<Trash className={"delete"} />
+						</Popconfirm>
+					</TableActionsWrapper>
+				)
+			},
+		},
+	]
+
+	const dataToDisplay: MeasureUnit[] = useMemo(() => {
+		if (!data?.units) return []
+		if (!mesureUnitSearchQuery) return data.units
+		return data.units.filter((unit) =>
+			unit.abrev.toLowerCase().includes(mesureUnitSearchQuery.toLowerCase()),
+		)
+	}, [data, mesureUnitSearchQuery])
+
+	return (
+		<TableWrapper>
+			<Table
+				columns={columns}
+				dataSource={dataToDisplay}
+				virtual={true}
+				loading={isLoading}
+				pagination={{
+					showSizeChanger: !!data?.totalPages && data?.totalPages > 5,
+					current: data?.currentPage,
+					total: data?.totalPages,
+					pageSize: Number(pageSize),
+					onChange: (page, size) => {
+						handlePagination(page, Number(pageSize))
+						if (size !== Number(pageSize)) {
+							handleChangePageSize(size)
+						}
+					},
+					disabled: mesureUnitsQuery.isPlaceholderData,
+				}}
+			/>
+		</TableWrapper>
+	)
+}

--- a/src/pages/Settings/MesureUnits/mesureUnitForm/index.tsx
+++ b/src/pages/Settings/MesureUnits/mesureUnitForm/index.tsx
@@ -1,12 +1,15 @@
 import { NewInput } from "@/components/NewInput"
 import { useGetNotification } from "@/hooks/useGetNotification"
 import {
-    EMPTY_MESURE_UNIT,
-    mesureUnitSchema,
-    type MesureUnitSchemaType,
+	EMPTY_MESURE_UNIT,
+	type MesureUnitSchemaType,
+	mesureUnitSchema,
 } from "@/pages/Settings/MesureUnits/mesureUnitForm/schema"
 import { type ErrorExtended, parseError } from "@/services/api"
-import { useGetProductsMesureUnits, useGetProductsMesureUnitsActions, } from "@/services/productsService"
+import {
+	useGetProductsMesureUnits,
+	useGetProductsMesureUnitsActions,
+} from "@/services/productsService"
 import { FormFooter, FormStyled } from "@/style/global"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { Button, Drawer } from "antd"
@@ -15,138 +18,138 @@ import { Controller, useForm } from "react-hook-form"
 import { useSearchParams } from "react-router-dom"
 
 export const MesureUnitForm = () => {
-    const [searchParams, setSearchParams] = useSearchParams()
-    const [isLoading, setIsLoading] = useState(false)
-    const {showNotification} = useGetNotification()
-    const {data: mesureUnits, query: mesureUnitsQuery} =
-        useGetProductsMesureUnits()
-    const {createProductMesureUnit, updateProductMesureUnit} =
-        useGetProductsMesureUnitsActions()
+	const [searchParams, setSearchParams] = useSearchParams()
+	const [isLoading, setIsLoading] = useState(false)
+	const { showNotification } = useGetNotification()
+	const { data: mesureUnits, query: mesureUnitsQuery } =
+		useGetProductsMesureUnits()
+	const { createProductMesureUnit, updateProductMesureUnit } =
+		useGetProductsMesureUnitsActions()
 
-    const isCreatingNew = searchParams.get("action") === "create_mesure_unit"
-    const mesureUnitId = searchParams.get("mesure_unit_id")
-    const isDrawerOpen = isCreatingNew || !!mesureUnitId
+	const isCreatingNew = searchParams.get("action") === "create_mesure_unit"
+	const mesureUnitId = searchParams.get("mesure_unit_id")
+	const isDrawerOpen = isCreatingNew || !!mesureUnitId
 
-    const handleCancel = () => {
-        setSearchParams((params) => {
-            params.delete("action")
-            params.delete("mesure_unit_id")
-            return params
-        })
-    }
+	const handleCancel = () => {
+		setSearchParams((params) => {
+			params.delete("action")
+			params.delete("mesure_unit_id")
+			return params
+		})
+	}
 
-    const initialValues = useMemo(() => {
-        if (!isCreatingNew && !mesureUnitId) {
-            return {
-                ...EMPTY_MESURE_UNIT,
-                id: crypto.randomUUID(),
-            }
-        }
-        const mesureUnit = mesureUnits?.units.find(
-            (mesureUnit) => mesureUnit.id === mesureUnitId,
-        )
-        if (!mesureUnit) return {...EMPTY_MESURE_UNIT, id: crypto.randomUUID()}
-        return {
-            description: mesureUnit.description,
-            abrev: mesureUnit.abrev,
-            id: mesureUnit.id,
-        }
-    }, [mesureUnitId, isCreatingNew, mesureUnits])
+	const initialValues = useMemo(() => {
+		if (!isCreatingNew && !mesureUnitId) {
+			return {
+				...EMPTY_MESURE_UNIT,
+				id: crypto.randomUUID(),
+			}
+		}
+		const mesureUnit = mesureUnits?.units.find(
+			(mesureUnit) => mesureUnit.id === mesureUnitId,
+		)
+		if (!mesureUnit) return { ...EMPTY_MESURE_UNIT, id: crypto.randomUUID() }
+		return {
+			description: mesureUnit.description,
+			abrev: mesureUnit.abrev,
+			id: mesureUnit.id,
+		}
+	}, [mesureUnitId, isCreatingNew, mesureUnits])
 
-    const onSubmit = async (data: MesureUnitSchemaType) => {
-        setIsLoading(true)
+	const onSubmit = async (data: MesureUnitSchemaType) => {
+		setIsLoading(true)
 
-        const body = {
-            description: data.description,
-            abrev: data.abrev,
-        }
+		const body = {
+			description: data.description,
+			abrev: data.abrev,
+		}
 
-        try {
-            mesureUnitId
-                ? await updateProductMesureUnit(mesureUnitId, body)
-                : await createProductMesureUnit(body)
-            await mesureUnitsQuery.refetch()
-            showNotification({
-                type: "SUCCESS",
-                message: isCreatingNew
-                    ? "Unidade de medida criada com sucesso"
-                    : "Unidade de medida atualizada com sucesso",
-                description: "",
-            })
-            handleCancel()
-        } catch (err) {
-            const parsedError = parseError(err as ErrorExtended)
-            showNotification({
-                type: "ERROR",
-                message: isCreatingNew
-                    ? "Erro ao criar unidade de medida"
-                    : "Erro ao atualizar unidade de medida",
-                description: parsedError ?? "Verifique seus dados e tente novamente",
-            })
-        } finally {
-            setIsLoading(false)
-        }
-    }
+		try {
+			mesureUnitId
+				? await updateProductMesureUnit(mesureUnitId, body)
+				: await createProductMesureUnit(body)
+			await mesureUnitsQuery.refetch()
+			showNotification({
+				type: "SUCCESS",
+				message: isCreatingNew
+					? "Unidade de medida criada com sucesso"
+					: "Unidade de medida atualizada com sucesso",
+				description: "",
+			})
+			handleCancel()
+		} catch (err) {
+			const parsedError = parseError(err as ErrorExtended)
+			showNotification({
+				type: "ERROR",
+				message: isCreatingNew
+					? "Erro ao criar unidade de medida"
+					: "Erro ao atualizar unidade de medida",
+				description: parsedError ?? "Verifique seus dados e tente novamente",
+			})
+		} finally {
+			setIsLoading(false)
+		}
+	}
 
-    const methods = useForm<MesureUnitSchemaType>({
-        resolver: yupResolver(mesureUnitSchema),
-        values: initialValues,
-        mode: "all",
-    })
+	const methods = useForm<MesureUnitSchemaType>({
+		resolver: yupResolver(mesureUnitSchema),
+		values: initialValues,
+		mode: "all",
+	})
 
-    return (
-        <Drawer
-            title={
-                isCreatingNew ? "Novo unidade de medida" : "Editar unidade de medida"
-            }
-            open={isDrawerOpen}
-            width={600}
-            footer={false}
-            onClose={handleCancel}
-        >
-            <FormStyled onSubmit={methods.handleSubmit(onSubmit)}>
-                <Controller
-                    name={"abrev"}
-                    control={methods.control}
-                    render={({field}) => (
-                        <NewInput
-                            required
-                            label={"Abreviação"}
-                            placeholder={"Abreviação da unidade de medida"}
-                            errorMessage={methods.formState.errors.abrev?.message}
-                            {...field}
-                        />
-                    )}
-                />
-                <Controller
-                    name={"description"}
-                    control={methods.control}
-                    render={({field}) => (
-                        <NewInput
-                            label={"Descrição"}
-                            placeholder={"Descrição da unidade de medida"}
-                            errorMessage={methods.formState.errors.description?.message}
-                            {...field}
-                        />
-                    )}
-                />
-                <FormFooter>
-                    <Button onClick={handleCancel}>Cancelar</Button>
-                    <Button
-                        className="button2"
-                        htmlType="submit"
-                        type="primary"
-                        disabled={
-                            !methods.formState.isValid ||
-                            mesureUnitsQuery.isLoading ||
-                            isLoading
-                        }
-                        loading={isLoading}
-                    >
-                        Salvar
-                    </Button>
-                </FormFooter>
-            </FormStyled>
-        </Drawer>
-    )
+	return (
+		<Drawer
+			title={
+				isCreatingNew ? "Novo unidade de medida" : "Editar unidade de medida"
+			}
+			open={isDrawerOpen}
+			width={600}
+			footer={false}
+			onClose={handleCancel}
+		>
+			<FormStyled onSubmit={methods.handleSubmit(onSubmit)}>
+				<Controller
+					name={"abrev"}
+					control={methods.control}
+					render={({ field }) => (
+						<NewInput
+							required
+							label={"Abreviação"}
+							placeholder={"Abreviação da unidade de medida"}
+							errorMessage={methods.formState.errors.abrev?.message}
+							{...field}
+						/>
+					)}
+				/>
+				<Controller
+					name={"description"}
+					control={methods.control}
+					render={({ field }) => (
+						<NewInput
+							label={"Descrição"}
+							placeholder={"Descrição da unidade de medida"}
+							errorMessage={methods.formState.errors.description?.message}
+							{...field}
+						/>
+					)}
+				/>
+				<FormFooter>
+					<Button onClick={handleCancel}>Cancelar</Button>
+					<Button
+						className="button2"
+						htmlType="submit"
+						type="primary"
+						disabled={
+							!methods.formState.isValid ||
+							mesureUnitsQuery.isLoading ||
+							isLoading
+						}
+						loading={isLoading}
+					>
+						Salvar
+					</Button>
+				</FormFooter>
+			</FormStyled>
+		</Drawer>
+	)
 }

--- a/src/pages/Settings/MesureUnits/mesureUnitForm/index.tsx
+++ b/src/pages/Settings/MesureUnits/mesureUnitForm/index.tsx
@@ -1,0 +1,152 @@
+import { NewInput } from "@/components/NewInput"
+import { useGetNotification } from "@/hooks/useGetNotification"
+import {
+    EMPTY_MESURE_UNIT,
+    mesureUnitSchema,
+    type MesureUnitSchemaType,
+} from "@/pages/Settings/MesureUnits/mesureUnitForm/schema"
+import { type ErrorExtended, parseError } from "@/services/api"
+import { useGetProductsMesureUnits, useGetProductsMesureUnitsActions, } from "@/services/productsService"
+import { FormFooter, FormStyled } from "@/style/global"
+import { yupResolver } from "@hookform/resolvers/yup"
+import { Button, Drawer } from "antd"
+import { useMemo, useState } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { useSearchParams } from "react-router-dom"
+
+export const MesureUnitForm = () => {
+    const [searchParams, setSearchParams] = useSearchParams()
+    const [isLoading, setIsLoading] = useState(false)
+    const {showNotification} = useGetNotification()
+    const {data: mesureUnits, query: mesureUnitsQuery} =
+        useGetProductsMesureUnits()
+    const {createProductMesureUnit, updateProductMesureUnit} =
+        useGetProductsMesureUnitsActions()
+
+    const isCreatingNew = searchParams.get("action") === "create_mesure_unit"
+    const mesureUnitId = searchParams.get("mesure_unit_id")
+    const isDrawerOpen = isCreatingNew || !!mesureUnitId
+
+    const handleCancel = () => {
+        setSearchParams((params) => {
+            params.delete("action")
+            params.delete("mesure_unit_id")
+            return params
+        })
+    }
+
+    const initialValues = useMemo(() => {
+        if (!isCreatingNew && !mesureUnitId) {
+            return {
+                ...EMPTY_MESURE_UNIT,
+                id: crypto.randomUUID(),
+            }
+        }
+        const mesureUnit = mesureUnits?.units.find(
+            (mesureUnit) => mesureUnit.id === mesureUnitId,
+        )
+        if (!mesureUnit) return {...EMPTY_MESURE_UNIT, id: crypto.randomUUID()}
+        return {
+            description: mesureUnit.description,
+            abrev: mesureUnit.abrev,
+            id: mesureUnit.id,
+        }
+    }, [mesureUnitId, isCreatingNew, mesureUnits])
+
+    const onSubmit = async (data: MesureUnitSchemaType) => {
+        setIsLoading(true)
+
+        const body = {
+            description: data.description,
+            abrev: data.abrev,
+        }
+
+        try {
+            mesureUnitId
+                ? await updateProductMesureUnit(mesureUnitId, body)
+                : await createProductMesureUnit(body)
+            await mesureUnitsQuery.refetch()
+            showNotification({
+                type: "SUCCESS",
+                message: isCreatingNew
+                    ? "Unidade de medida criada com sucesso"
+                    : "Unidade de medida atualizada com sucesso",
+                description: "",
+            })
+            handleCancel()
+        } catch (err) {
+            const parsedError = parseError(err as ErrorExtended)
+            showNotification({
+                type: "ERROR",
+                message: isCreatingNew
+                    ? "Erro ao criar unidade de medida"
+                    : "Erro ao atualizar unidade de medida",
+                description: parsedError ?? "Verifique seus dados e tente novamente",
+            })
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    const methods = useForm<MesureUnitSchemaType>({
+        resolver: yupResolver(mesureUnitSchema),
+        values: initialValues,
+        mode: "all",
+    })
+
+    return (
+        <Drawer
+            title={
+                isCreatingNew ? "Novo unidade de medida" : "Editar unidade de medida"
+            }
+            open={isDrawerOpen}
+            width={600}
+            footer={false}
+            onClose={handleCancel}
+        >
+            <FormStyled onSubmit={methods.handleSubmit(onSubmit)}>
+                <Controller
+                    name={"abrev"}
+                    control={methods.control}
+                    render={({field}) => (
+                        <NewInput
+                            required
+                            label={"Abreviação"}
+                            placeholder={"Abreviação da unidade de medida"}
+                            errorMessage={methods.formState.errors.abrev?.message}
+                            {...field}
+                        />
+                    )}
+                />
+                <Controller
+                    name={"description"}
+                    control={methods.control}
+                    render={({field}) => (
+                        <NewInput
+                            label={"Descrição"}
+                            placeholder={"Descrição da unidade de medida"}
+                            errorMessage={methods.formState.errors.description?.message}
+                            {...field}
+                        />
+                    )}
+                />
+                <FormFooter>
+                    <Button onClick={handleCancel}>Cancelar</Button>
+                    <Button
+                        className="button2"
+                        htmlType="submit"
+                        type="primary"
+                        disabled={
+                            !methods.formState.isValid ||
+                            mesureUnitsQuery.isLoading ||
+                            isLoading
+                        }
+                        loading={isLoading}
+                    >
+                        Salvar
+                    </Button>
+                </FormFooter>
+            </FormStyled>
+        </Drawer>
+    )
+}

--- a/src/pages/Settings/MesureUnits/mesureUnitForm/schema.ts
+++ b/src/pages/Settings/MesureUnits/mesureUnitForm/schema.ts
@@ -1,0 +1,13 @@
+import * as yup from "yup"
+
+export const mesureUnitSchema = yup.object().shape({
+	description: yup.string(),
+	abrev: yup.string().required("Campo obrigatório"),
+})
+
+export type MesureUnitSchemaType = yup.InferType<typeof mesureUnitSchema>
+
+export const EMPTY_MESURE_UNIT: MesureUnitSchemaType = {
+	description: "",
+	abrev: "",
+}

--- a/src/pages/Settings/ProductsType/list/index.tsx
+++ b/src/pages/Settings/ProductsType/list/index.tsx
@@ -11,6 +11,10 @@ import { Pencil, Trash } from "phosphor-react"
 import { useMemo, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 
+const IN_USE_TITLE = "Este tipo de produto está associado a um ou mais produtos"
+const NOT_IN_USE_TITLE =
+	"Este tipo de produto não está associado a nenhum produto"
+
 export const ProductsTypeList = () => {
 	const { data, isLoading, query: productsTypesQuery } = useGetProductsTypes()
 	const [searchParams, setSearchParams] = useSearchParams()
@@ -64,16 +68,33 @@ export const ProductsTypeList = () => {
 			render: (_, record) => record?.id,
 		},
 		{
-			title: "Produtos associados",
+			title: "Status",
 			dataIndex: "products",
 			key: "products",
-			render: (_, record) => (
-				<Tag color={record?.products > 0 ? "green" : "red"}>
-					{record?.products}
-				</Tag>
-			),
-			sorter: (a, b) => a?.products - b?.products,
-			sortDirections: ["descend", "ascend"],
+			render: (_, record) => {
+				const isInUse = record?.products > 0
+				return (
+					<Tooltip title={isInUse ? IN_USE_TITLE : NOT_IN_USE_TITLE}>
+						<Tag color={isInUse ? "green" : "red"}>
+							{isInUse ? "Em uso" : "Inutilizado"}
+						</Tag>
+					</Tooltip>
+				)
+			},
+			filters: [
+				{
+					text: "Em uso",
+					value: true,
+				},
+				{
+					text: "Inutilizado",
+					value: false,
+				},
+			],
+			onFilter: (value, record) => {
+				const isInUse = record?.products > 0
+				return isInUse === value
+			},
 		},
 		{
 			title: "",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,7 @@ import Orders from "@/pages/Orders"
 import Products from "@/pages/Products"
 import ResetPassword from "@/pages/ResetPassword"
 import Section from "@/pages/Section"
+import { ManageMesureUnits } from "@/pages/Settings/MesureUnits"
 import { ManageProductsType } from "@/pages/Settings/ProductsType"
 import Profile from "@/pages/Settings/Profile"
 import Users from "@/pages/Settings/Users"
@@ -125,6 +126,15 @@ export const router = createBrowserRouter([
 							{
 								index: true,
 								element: <ManageProductsType />,
+							},
+						],
+					},
+					{
+						path: "unidades-de-medida",
+						children: [
+							{
+								index: true,
+								element: <ManageMesureUnits />,
 							},
 						],
 					},

--- a/src/services/productsService.ts
+++ b/src/services/productsService.ts
@@ -186,3 +186,77 @@ export const useGetProductsTypesActions = () => {
 		updateProductType,
 	}
 }
+
+type MeasureUnit = {
+	id: string
+	description: string
+	abrev: string
+}
+
+type UnitsResponse = {
+	units: MeasureUnit[]
+}
+
+export const useGetProductsMesureUnits = () => {
+	const url = "/units"
+	const token = useUserStore((state) => state.token)
+	const headers = makeApiHeaders(token)
+
+	const query = useQuery({
+		queryKey: [url],
+		queryFn: () =>
+			ApiInstance.get<PaginatedResponse<UnitsResponse>>(url, { headers }),
+		enabled: !!token,
+	})
+
+	return {
+		data: query.data,
+		isLoading: query.isLoading,
+		error: query.error,
+		query,
+	}
+}
+
+type UnitsMesureBody = {
+	description: string
+	abrev: string
+}
+
+export const useGetProductsMesureUnitsActions = () => {
+	const token = useUserStore((state) => state.token)
+	const headers = makeApiHeaders(token)
+
+	const createProductMesureUnit = async (data: UnitsMesureBody) => {
+		const url = "/units/new"
+		return await ApiInstance.post<UnitsMesureBody, MeasureUnit>(url, data, {
+			headers,
+		})
+	}
+
+	const deleteProductMesureUnit = async (id: string) => {
+		const url = `/units/${id}/delete`
+		return await ApiInstance.delete(url, {
+			headers,
+		})
+	}
+
+	const updateProductMesureUnit = async (
+		id: string,
+		data: Partial<MeasureUnit>,
+	) => {
+		const url = `/units/${id}/edit`
+		return await ApiInstance.patch<Partial<MeasureUnit>, MeasureUnit>(
+			url,
+			data,
+			{
+				headers,
+			},
+		)
+	}
+
+	return {
+		createProductMesureUnit,
+		deleteProductMesureUnit,
+		updateProductMesureUnit,
+	}
+}

--- a/src/services/productsService.ts
+++ b/src/services/productsService.ts
@@ -187,9 +187,9 @@ export const useGetProductsTypesActions = () => {
 	}
 }
 
-type MeasureUnit = {
+export type MeasureUnit = {
 	id: string
-	description: string
+	description?: string
 	abrev: string
 }
 
@@ -218,7 +218,7 @@ export const useGetProductsMesureUnits = () => {
 }
 
 type UnitsMesureBody = {
-	description: string
+	description?: string
 	abrev: string
 }
 


### PR DESCRIPTION
# 🎉 Novidades

## Descrição Geral
Nesta pull request, foram implementadas diversas funcionalidades e melhorias relacionadas ao gerenciamento de unidades de medida, tanto na listagem e edição quanto na aplicação dentro do formulário de produtos. Foram feitas também melhorias na interface e na legibilidade do código.

## 🆕 feat(product-units): adicionar funcionalidade de gerenciamento de unidades de medida dos produtos
- Adicionado type MeasureUnit e UnitsResponse para tipagem das unidades de medida
- Criado hook `useGetProductsMeasureUnits` para buscar unidades de medida
- Criado hook `useGetProductsMeasureUnitsActions` para ações CRUD em unidades de medida
- Modificado `ProductForm` para utilizar os novos hooks relacionados às unidades de medida
- Integrado dropdown no formulário de produtos para selecionar e adicionar novas unidades de medida
- Ajuste na função `handleAddMeasureUnit` para criação de novas unidades de medida
- Atualizado render do componente `DropDownWithCreate` para utilizar unidades de medida
- Removido código comentado e desnecessário referente a tipos de produtos

## ✨ feat: adicionar funcionalidades de gerenciamento de unidades de medida
- Criada a tela de listagem de unidades de medida com filtro e paginação
- Implementado formulário para criação e edição de unidades de medida
- Adicionada a função de deletar unidades de medida com confirmação
- Ajustada a definição de tipos e validações com yup
- Incorporada a rota de unidades de medida nas configurações
- Adicionado item no menu para acesso às unidades de medida
- Integrado carregamento e salvamento de dados pela API
- Configurado estado de carregamento para operações de formulário
- Melhorada a experiência do usuário com notificações de sucesso e erro
- Estabelecido esquema padrão vazio para unidade de medida

## 💡 feat: adicionar nova funcionalidade e melhorias gerais
- Adicionada coluna "Unidade de medida" na lista de produtos com renderização apropriada
- Alterado título e comportamento da coluna "Status" em tipos de produto
- Implementados tooltips explicativos na coluna "Status" dos tipos de produto
- Adicionados filtros por status de uso na lista de tipos de produto
- Ajustada formatação do código para melhor legibilidade e consistência
- Atualizada referência ao ícone no menu "Un de medida"
- Mantidos valores iniciais no formulário de unidade de medida com `useMemo`
- Refatorada a lógica de envio de formulário com `async/await` e tratamento de erros
- Adicionada legibilidade ao código com formatação de importações e construtores